### PR TITLE
Fix import syntax error in config file

### DIFF
--- a/frontend/config.js
+++ b/frontend/config.js
@@ -7,8 +7,7 @@ function isLocalHost(host) {
 
 // Configuration globale pour l'application
 window.APP_CONFIG = {
-  API_URL: (typeof import !== "undefined" && import.meta?.env?.VITE_API_BASE_URL) || 
-           (typeof window !== "undefined" && isLocalHost(window.location.hostname) ? "http://localhost:3000" : PROD_API)
+  API_URL: (typeof window !== "undefined" && isLocalHost(window.location.hostname) ? "http://localhost:3000" : PROD_API)
 };
 
 // Export pour compatibilité avec les modules ES6 si nécessaire


### PR DESCRIPTION
Remove `import.meta` usage from `config.js` to fix `SyntaxError: Cannot use import statement outside a module`.

The `config.js` file was not loaded as an ES module, causing a syntax error when `import.meta` was used. This change simplifies the API URL determination to only use `isLocalHost` detection, which is sufficient for the application's needs.

---
<a href="https://cursor.com/background-agent?bcId=bc-6e040cf4-d979-40d5-a1c7-b221cc5312f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6e040cf4-d979-40d5-a1c7-b221cc5312f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

