### PR TITLE
Fix config.js import syntax error

### DIFF
--- a/frontend/config.js
+++ b/frontend/config.js
@@ -7,8 +7,7 @@ function isLocalHost(host) {
 
 // Configuration globale pour l'application
 window.APP_CONFIG = {
-  API_URL: (typeof import !== "undefined" && import.meta?.env?.VITE_API_BASE_URL) || 
-           (typeof window !== "undefined" && isLocalHost(window.location.hostname) ? "http://localhost:3000" : PROD_API)
+  API_URL: (typeof window !== "undefined" && isLocalHost(window.location.hostname) ? "http://localhost:3000" : PROD_API)
 };
 
 // Export pour compatibilité avec les modules ES6 si nécessaire


### PR DESCRIPTION
Remove `import.meta` check from `config.js` to resolve `SyntaxError` when loaded as a regular script.

---
<a href="https://cursor.com/background-agent?bcId=bc-ab16cafa-ba4a-43a8-924b-3e4462534a39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ab16cafa-ba4a-43a8-924b-3e4462534a39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

