### PR TITLE
Fix map display import error

### DIFF
--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -83,7 +83,10 @@ function applyTheme(mode) {
   document.body.style.color = isDark ? "#E8EEF4" : "#0E1A22";
 }
 
-// Export pour les modules ES6
+// Export ES6
+export { initCommonUI, applyTheme };
+
+// Export CommonJS pour compatibilité
 if (typeof module !== 'undefined' && module.exports) {
   module.exports = { initCommonUI, applyTheme };
 }


### PR DESCRIPTION
Add ES6 exports to `ui.js` to fix a `SyntaxError` preventing `map.js` from importing `initCommonUI`.

---
<a href="https://cursor.com/background-agent?bcId=bc-cfef4102-7a4b-48aa-b468-9095bd96668c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cfef4102-7a4b-48aa-b468-9095bd96668c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

