### PR TITLE
Show all cliff locations at max cursor

### DIFF
--- a/frontend/map.html
+++ b/frontend/map.html
@@ -67,6 +67,13 @@
           <option value="9">9</option>
         </select>
       </div>
+      
+      <div class="filter-group">
+        <label for="filterDistance">
+          Distance: <span id="distanceValue">Toutes</span>
+        </label>
+        <input type="range" id="filterDistance" min="0" max="500" value="500" step="10">
+      </div>
     </div>
 
     <!-- Bottom sheet pour fiche spot -->

--- a/frontend/style/style.css
+++ b/frontend/style/style.css
@@ -321,6 +321,19 @@ p, input, select, textarea, .card p, label, .footer { font-family: var(--font-bo
 
 .filter-group input[type="range"]{
   width:100%;
+  cursor: pointer;
+  accent-color: var(--c1);
+}
+
+.filter-group label {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+#distanceValue {
+  font-weight: 700;
+  color: var(--c1);
 }
 
 /* --- Bottom Sheet au-dessus de la carte --- */


### PR DESCRIPTION
Add a distance filter with a slider to the map, allowing users to filter climbing spots by proximity or show all locations.

---
<a href="https://cursor.com/background-agent?bcId=bc-350ba73b-f4d0-4143-8276-4a78a7eac98b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-350ba73b-f4d0-4143-8276-4a78a7eac98b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

