### PR TITLE
Handle unexpected end of json input error

### DIFF
--- a/backend/src/routes/spots.routes.js
+++ b/backend/src/routes/spots.routes.js
@@ -207,7 +207,7 @@ export function spotsRouter(db) {
   // --- Mettre à jour un spot (PATCH) ---
   r.patch("/:id", async (req, res) => {
     if (!ObjectId.isValid(req.params.id)) {
-      return res.status(400).json({ error: "bad_id" });
+      return res.status(400).json({ error: "bad_id", detail: "ID invalide" });
     }
     
     try {
@@ -230,16 +230,19 @@ export function spotsRouter(db) {
       );
       
       if (!result) {
-        return res.status(404).json({ error: "not_found" });
+        return res.status(404).json({ error: "not_found", detail: "Spot introuvable" });
       }
       
-      res.json({ ok: true, spot: result });
+      return res.status(200).json({ ok: true, spot: result });
     } catch (e) {
       if (e.name === 'ZodError') {
-        return res.status(400).json({ error: "invalid_payload", detail: String(e) });
+        return res.status(400).json({ 
+          error: "invalid_payload", 
+          detail: e.errors?.map(err => `${err.path.join('.')}: ${err.message}`).join(', ') || String(e)
+        });
       }
-      console.error(e);
-      res.status(500).json({ error: "server_error" });
+      console.error('[PATCH /spots/:id] Error:', e);
+      return res.status(500).json({ error: "server_error", detail: "Erreur interne du serveur" });
     }
   });
 

--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -147,12 +147,16 @@ async function tryFetch(url) {
 
   // Certains proxies renvoient 204/empty → gérons-le proprement
   const txt = await r.text();
-  if (!txt) return null;
+  if (!txt || txt.trim() === '') {
+    console.warn('[api] Empty response from:', url);
+    return null;
+  }
 
   try {
     return JSON.parse(txt);
   } catch (parseErr) {
-    throw new Error(`[json_parse_error] ${String(parseErr)} — preview: ${txt.slice(0, 200)}`);
+    console.error('[api] JSON parse error:', parseErr, 'URL:', url, 'Response preview:', txt.slice(0, 200));
+    throw new Error(`[json_parse_error] Réponse invalide du serveur. Preview: ${txt.slice(0, 100)}`);
   }
 }
 

--- a/frontend/js/map.js
+++ b/frontend/js/map.js
@@ -402,12 +402,24 @@ window.submitSpotEdit = async function(spotId) {
       body: JSON.stringify(updates)
     });
     
-    if (!response.ok) {
-      const error = await response.json();
-      throw new Error(error.error || 'Erreur lors de la modification');
+    // Récupérer le texte brut de la réponse
+    const responseText = await response.text();
+    
+    // Parser le JSON seulement si la réponse n'est pas vide
+    let result = null;
+    if (responseText) {
+      try {
+        result = JSON.parse(responseText);
+      } catch (parseError) {
+        console.error('Erreur de parsing JSON:', parseError, 'Réponse:', responseText);
+        throw new Error('Réponse invalide du serveur');
+      }
     }
     
-    const result = await response.json();
+    if (!response.ok) {
+      const errorMsg = result?.error || result?.detail || 'Erreur lors de la modification';
+      throw new Error(errorMsg);
+    }
     
     // Mettre à jour le spot dans allSpots
     const spotIndex = allSpots.findIndex(s => s.id === spotId);


### PR DESCRIPTION
Fix "Unexpected end of JSON input" error by improving frontend JSON response handling and backend error messaging.

The error occurred because the frontend was attempting to parse `response.json()` on empty or malformed responses, and the backend's error messages were not detailed enough. This PR ensures robust JSON parsing on the frontend and provides clearer, more consistent error responses from the backend.

---
<a href="https://cursor.com/background-agent?bcId=bc-e5b896f4-c8d4-4e13-8d5a-1d3d6dbc0aa3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e5b896f4-c8d4-4e13-8d5a-1d3d6dbc0aa3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

