### PR TITLE
Handle spot edit submission errors

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -48,15 +48,21 @@ function isAllowedOrigin(origin) {
   return false;
 }
 
-app.use(
-  cors({
-    origin: (origin, cb) => {
-      if (isAllowedOrigin(origin)) return cb(null, true);
-      cb(new Error("Not allowed by CORS"));
-    },
-    credentials: true,
-  })
-);
+// --- CORS configuration with all methods
+const corsConfig = {
+  origin: (origin, cb) => {
+    if (isAllowedOrigin(origin)) return cb(null, true);
+    cb(new Error("Not allowed by CORS"));
+  },
+  credentials: true,
+  methods: ["GET", "POST", "PATCH", "PUT", "DELETE", "OPTIONS"],
+  allowedHeaders: ["Authorization", "Content-Type", "Accept"],
+  exposedHeaders: ["Content-Type", "Content-Length"],
+  optionsSuccessStatus: 200,
+};
+
+app.use(cors(corsConfig));
+app.options("*", cors(corsConfig));
 
 // --- Health endpoints
 app.get("/api/health", (_, res) => res.json({ ok: true }));
@@ -95,23 +101,6 @@ if (hasUri) {
 
   console.warn("MONGODB_URI manquante → mode sans DB (listes vides)");
 }
-
-// --- CORS (unique)
-const corsConfig = {
-  origin: (origin, cb) => {
-    if (isAllowedOrigin(origin)) return cb(null, true);
-    cb(new Error("Not allowed by CORS"));
-  },
-  credentials: true,
-  methods: ["GET", "POST", "PATCH", "DELETE", "OPTIONS"],
-  allowedHeaders: ["Authorization", "Content-Type", "Accept"],
-  exposedHeaders: ["Content-Type", "Content-Length"],
-  optionsSuccessStatus: 200,
-};
-
-app.use(cors(corsConfig));
-app.options("*", cors(corsConfig));
-
 
 // --- Listen (0.0.0.0 pour conteneur)
 const port = process.env.PORT || 3000;


### PR DESCRIPTION
Consolidate duplicate CORS configurations and explicitly allow PATCH method to fix "405 Method Not Allowed" error when editing spots.

The server had two CORS configurations. The first one, applied before routes, did not include PATCH in its allowed methods, causing the 405 error. The second, more complete CORS configuration was applied after routes, rendering it ineffective for pre-flight checks. This PR removes the duplicate and ensures a single, comprehensive CORS policy is applied correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-e36078a1-b3a3-45ea-927b-193a85166fbb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e36078a1-b3a3-45ea-927b-193a85166fbb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

