### PR TITLE
Fix import syntax in config file

### DIFF
--- a/frontend/config.js
+++ b/frontend/config.js
@@ -7,8 +7,7 @@ function isLocalHost(host) {
 
 // Configuration globale pour l'application
 window.APP_CONFIG = {
-  API_URL: (typeof import !== "undefined" && import.meta?.env?.VITE_API_BASE_URL) || 
-           (typeof window !== "undefined" && isLocalHost(window.location.hostname) ? "http://localhost:3000" : PROD_API)
+  API_URL: (typeof window !== "undefined" && isLocalHost(window.location.hostname) ? "http://localhost:3000" : PROD_API)
 };
 
 // Export pour compatibilité avec les modules ES6 si nécessaire

--- a/frontend/config.js
+++ b/frontend/config.js
@@ -7,10 +7,10 @@ function isLocalHost(host) {
 
 // Configuration globale pour l'application
 window.APP_CONFIG = {
-  API_URL: (typeof window !== "undefined" && isLocalHost(window.location.hostname) ? "http://localhost:3000" : PROD_API)
+  API_URL: window && window.location && isLocalHost(window.location.hostname) ? "http://localhost:3000" : PROD_API
 };
 
 // Export pour compatibilité avec les modules ES6 si nécessaire
-if (typeof module !== 'undefined' && module.exports) {
+if (typeof module != 'undefined' && module.exports) {
   module.exports = { API_BASE_URL: window.APP_CONFIG.API_URL };
 }


### PR DESCRIPTION
Remove `import.meta` reference from `config.js` to fix `SyntaxError` when loaded as a regular script.

The `import.meta` syntax is only valid in ES modules. Since `config.js` is loaded as a standard script in most contexts, using `import.meta?.env?.VITE_API_BASE_URL` caused a parse-time `SyntaxError`, which the `typeof import` check could not prevent.

---
<a href="https://cursor.com/background-agent?bcId=bc-4128654a-73b0-40da-8ee5-67c298e4a903"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4128654a-73b0-40da-8ee5-67c298e4a903"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

