### PR TITLE
Fix burger menu on material and settings pages

### DIFF
--- a/frontend/js/materiel-smart.js
+++ b/frontend/js/materiel-smart.js
@@ -106,8 +106,9 @@ const MATERIAL_CONFIG = {
 let listEl, addBtn, modal, form, title, search, tagFilter;
 
 function initializeUIElements() {
-  if (typeof initCommonUI === 'function') {
+  if (typeof initCommonUI === 'function' && !document.body.hasAttribute('data-ui-initialized')) {
     initCommonUI();
+    document.body.setAttribute('data-ui-initialized', 'true');
   }
   listEl = document.getElementById("gearList");
   addBtn = document.getElementById("addGearBtn");

--- a/frontend/js/parametres.js
+++ b/frontend/js/parametres.js
@@ -5,9 +5,10 @@
 const API_BASE_URL = window.APP_CONFIG?.API_URL || "http://localhost:3000";
 const API_PATH_PREFIX = "/api";
 
-// Initialiser l'UI commune
-if (typeof initCommonUI === 'function') {
+// Initialiser l'UI commune (ui.js s'auto-initialise maintenant)
+if (typeof initCommonUI === 'function' && !document.body.hasAttribute('data-ui-initialized')) {
   initCommonUI();
+  document.body.setAttribute('data-ui-initialized', 'true');
 }
 
 /* ---------- Session (localStorage.auth) ---------- */

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -90,3 +90,23 @@ export { initCommonUI, applyTheme };
 if (typeof module !== 'undefined' && module.exports) {
   module.exports = { initCommonUI, applyTheme };
 }
+
+// Expose globally for non-module scripts
+if (typeof window !== 'undefined') {
+  window.initCommonUI = initCommonUI;
+  window.applyTheme = applyTheme;
+}
+
+// Auto-initialize if not in module context
+if (typeof document !== 'undefined' && document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', () => {
+    // Only auto-init if initCommonUI hasn't been called yet
+    if (!document.body.hasAttribute('data-ui-initialized')) {
+      initCommonUI();
+      document.body.setAttribute('data-ui-initialized', 'true');
+    }
+  });
+} else if (typeof document !== 'undefined' && !document.body.hasAttribute('data-ui-initialized')) {
+  initCommonUI();
+  document.body.setAttribute('data-ui-initialized', 'true');
+}


### PR DESCRIPTION
Fix burger menu functionality on `materiel` and `parametres` pages by ensuring `initCommonUI` is correctly called and exposed.

The `ui.js` script, which contains the `initCommonUI()` function for the burger menu, was not consistently initialized across all pages. `parametres.html` loaded `ui.js` as a non-module script without global exposure, and `materiel.html` loaded it as a module but didn't explicitly import and call the function. This PR modifies `ui.js` to expose its functions globally and auto-initialize itself upon DOM load, while also adding safeguards to prevent double initialization. The calling scripts (`parametres.js` and `materiel-smart.js`) were updated to respect this new auto-initialization mechanism.

---
<a href="https://cursor.com/background-agent?bcId=bc-f35841a3-2124-4a9d-9a56-5d54ab6ab14a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f35841a3-2124-4a9d-9a56-5d54ab6ab14a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

