### PR TITLE
Add all equipment types to user

### DIFF
--- a/backend/src/routes/materielSpecs.routes.js
+++ b/backend/src/routes/materielSpecs.routes.js
@@ -70,6 +70,17 @@ export function materielSpecsRouter(db) {
     }
   });
 
+  // --- Récupérer toutes les catégories distinctes ---
+  r.get("/categories", async (req, res) => {
+    try {
+      const categories = await specs.distinct("category");
+      res.json({ categories: categories.sort() });
+    } catch (e) {
+      console.error(e);
+      res.status(500).json({ error: "server_error" });
+    }
+  });
+
   // --- Lister les matériels ---
   r.get("/", async (req, res) => {
     try {

--- a/frontend/materiel.html
+++ b/frontend/materiel.html
@@ -48,14 +48,7 @@
         <input id="gearSearch" class="input" placeholder="Rechercher…" />
         <select id="gearTagFilter" class="select">
           <option value="">Toutes catégories</option>
-          <option value="Corde">Corde</option>
-          <option value="Dégaines">Dégaines</option>
-          <option value="Casque">Casque</option>
-          <option value="Baudrier">Baudrier</option>
-          <option value="Chaussons">Chaussons</option>
-          <option value="Mousquetons">Mousquetons</option>
-          <option value="Longe">Longe</option>
-          <option value="Autre">Autre</option>
+          <!-- Les catégories seront chargées dynamiquement depuis l'API -->
         </select>
         <button type="button" id="addGearBtn" class="btn" aria-label="Ajouter un équipement">
           ➕ Ajouter un équipement


### PR DESCRIPTION
Implement dynamic loading of material categories to ensure all `Materiel_Specs` categories are available in the UI.

The previous implementation used a hardcoded list of material categories in the frontend JavaScript, which was incomplete and did not reflect all categories defined in the `Materiel_Specs` collection. This PR updates the frontend to fetch categories directly from a new backend API endpoint, ensuring consistency and completeness.

---
<a href="https://cursor.com/background-agent?bcId=bc-fdc32b00-f6d3-4ddd-b8c6-95d2782ce496"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fdc32b00-f6d3-4ddd-b8c6-95d2782ce496"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

